### PR TITLE
Add basic tests for shared UI components

### DIFF
--- a/src/shared/ui/OtpInputBoxes.test.tsx
+++ b/src/shared/ui/OtpInputBoxes.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import OtpInputBoxes from "./OtpInputBoxes";
+
+function Wrapper({ length = 4, onComplete }: { length?: number; onComplete?: (val: string) => void }) {
+  const [value, setValue] = useState("");
+  return (
+    <OtpInputBoxes
+      value={value}
+      onChange={setValue}
+      length={length}
+      onComplete={onComplete}
+    />
+  );
+}
+
+describe("OtpInputBoxes", () => {
+  it("يجب أن يعرض عدد الحقول الصحيح", () => {
+    render(<Wrapper length={4} />);
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(4);
+  });
+
+  it("يجب أن يستدعي onComplete عند إدخال جميع الأرقام", async () => {
+    const user = userEvent.setup();
+    const handleComplete = vi.fn();
+    render(<Wrapper length={4} onComplete={handleComplete} />);
+    const firstInput = screen.getAllByRole("textbox")[0];
+    await user.type(firstInput, "1234");
+    expect(handleComplete).toHaveBeenCalledWith("1234");
+  });
+});
+

--- a/src/shared/ui/SetupChecklist.test.tsx
+++ b/src/shared/ui/SetupChecklist.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SetupChecklist } from "./SetupChecklist";
+
+describe("SetupChecklist", () => {
+  it("يعرض رسالة البداية عند عدم إكمال أي خطوة", () => {
+    const status = {
+      merchantInfo: false,
+      productsSetup: false,
+      channelsConnected: [],
+      webchatConfigured: false,
+      promptConfigured: false,
+    };
+    render(<SetupChecklist status={status} onGoToStep={() => {}} />);
+    expect(screen.getByText("لنبدأ الرحلة!")).toBeInTheDocument();
+  });
+
+  it("يعرض رسالة الإكمال عند إنجاز جميع الخطوات", () => {
+    const status = {
+      merchantInfo: true,
+      productsSetup: true,
+      channelsConnected: ["whatsapp"],
+      webchatConfigured: true,
+      promptConfigured: true,
+    };
+    render(<SetupChecklist status={status} onGoToStep={() => {}} />);
+    expect(
+      screen.getByText("تهانينا! لقد أكملت كل شيء بنجاح!")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("لقد أكملت جميع خطوات التهيئة بنجاح!")
+    ).toBeInTheDocument();
+  });
+});
+

--- a/src/shared/ui/TagsInput.test.tsx
+++ b/src/shared/ui/TagsInput.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import TagsInput from "./TagsInput";
+
+describe("TagsInput", () => {
+  it("يعرض التسمية بشكل صحيح", () => {
+    render(<TagsInput label="التصنيفات" value={[]} onChange={() => {}} />);
+    expect(screen.getByLabelText("التصنيفات")).toBeInTheDocument();
+  });
+
+  it("يسمح بإضافة وسوم جديدة", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    function Wrapper() {
+      const [tags, setTags] = useState<string[]>([]);
+      return (
+        <TagsInput
+          label="التصنيفات"
+          value={tags}
+          onChange={(newTags) => {
+            setTags(newTags);
+            handleChange(newTags);
+          }}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    const input = screen.getByLabelText("التصنيفات");
+    await user.type(input, "hello{enter}");
+    expect(handleChange).toHaveBeenCalledWith(["hello"]);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for OTP input boxes including completion callback
- cover tags input with interaction test
- verify setup checklist messages for start and completion states

## Testing
- `npm test -- --run src/shared/ui`
- `npm run lint` *(fails: Unexpected any ... etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad8680048322b4ba82ca6d9a0d2a