### PR TITLE
test: add placeholder tests for merchant UI components

### DIFF
--- a/src/features/mechant/MissingResponses/ui/AddToKnowledgeDialog.test.tsx
+++ b/src/features/mechant/MissingResponses/ui/AddToKnowledgeDialog.test.tsx
@@ -1,0 +1,5 @@
+import AddToKnowledgeDialog from "./AddToKnowledgeDialog";
+
+test("AddToKnowledgeDialog should be defined", () => {
+  expect(AddToKnowledgeDialog).toBeDefined();
+});

--- a/src/features/mechant/categories/ui/AddCategoryDialog.test.tsx
+++ b/src/features/mechant/categories/ui/AddCategoryDialog.test.tsx
@@ -1,0 +1,5 @@
+import AddCategoryDialog from "./AddCategoryDialog";
+
+test("AddCategoryDialog should be defined", () => {
+  expect(AddCategoryDialog).toBeDefined();
+});

--- a/src/features/mechant/categories/ui/CategoryTree.test.tsx
+++ b/src/features/mechant/categories/ui/CategoryTree.test.tsx
@@ -1,0 +1,5 @@
+import CategoryTree from "./CategoryTree";
+
+test("CategoryTree should be defined", () => {
+  expect(CategoryTree).toBeDefined();
+});

--- a/src/features/mechant/categories/ui/DeleteCategoryDialog.test.tsx
+++ b/src/features/mechant/categories/ui/DeleteCategoryDialog.test.tsx
@@ -1,0 +1,5 @@
+import DeleteCategoryDialog from "./DeleteCategoryDialog";
+
+test("DeleteCategoryDialog should be defined", () => {
+  expect(DeleteCategoryDialog).toBeDefined();
+});

--- a/src/features/mechant/categories/ui/EditCategoryDialog.test.tsx
+++ b/src/features/mechant/categories/ui/EditCategoryDialog.test.tsx
@@ -1,0 +1,5 @@
+import EditCategoryDialog from "./EditCategoryDialog";
+
+test("EditCategoryDialog should be defined", () => {
+  expect(EditCategoryDialog).toBeDefined();
+});

--- a/src/features/mechant/channels/ui/TelegramConnectDialog.test.tsx
+++ b/src/features/mechant/channels/ui/TelegramConnectDialog.test.tsx
@@ -1,0 +1,5 @@
+import TelegramConnectDialog from "./TelegramConnectDialog";
+
+test("TelegramConnectDialog should be defined", () => {
+  expect(TelegramConnectDialog).toBeDefined();
+});

--- a/src/features/mechant/channels/ui/WebchatConnectDialog.test.tsx
+++ b/src/features/mechant/channels/ui/WebchatConnectDialog.test.tsx
@@ -1,0 +1,5 @@
+import WebchatConnectDialog from "./WebchatConnectDialog";
+
+test("WebchatConnectDialog should be defined", () => {
+  expect(WebchatConnectDialog).toBeDefined();
+});

--- a/src/features/mechant/channels/ui/WhatsappApiConnectDialog.test.tsx
+++ b/src/features/mechant/channels/ui/WhatsappApiConnectDialog.test.tsx
@@ -1,0 +1,5 @@
+import WhatsappApiConnectDialog from "./WhatsappApiConnectDialog";
+
+test("WhatsappApiConnectDialog should be defined", () => {
+  expect(WhatsappApiConnectDialog).toBeDefined();
+});

--- a/src/features/mechant/channels/ui/WhatsappQrConnect.test.tsx
+++ b/src/features/mechant/channels/ui/WhatsappQrConnect.test.tsx
@@ -1,0 +1,5 @@
+import WhatsappQrConnect from "./WhatsappQrConnect";
+
+test("WhatsappQrConnect should be defined", () => {
+  expect(WhatsappQrConnect).toBeDefined();
+});

--- a/src/features/mechant/knowledge/ui/DocsTab.test.tsx
+++ b/src/features/mechant/knowledge/ui/DocsTab.test.tsx
@@ -1,0 +1,5 @@
+import DocsTab from "./DocsTab";
+
+test("DocsTab should be defined", () => {
+  expect(DocsTab).toBeDefined();
+});

--- a/src/features/mechant/knowledge/ui/FaqsTab.test.tsx
+++ b/src/features/mechant/knowledge/ui/FaqsTab.test.tsx
@@ -1,0 +1,5 @@
+import FaqsTab from "./FaqsTab";
+
+test("FaqsTab should be defined", () => {
+  expect(FaqsTab).toBeDefined();
+});

--- a/src/features/mechant/knowledge/ui/LinksTab.test.tsx
+++ b/src/features/mechant/knowledge/ui/LinksTab.test.tsx
@@ -1,0 +1,5 @@
+import LinksTab from "./LinksTab";
+
+test("LinksTab should be defined", () => {
+  expect(LinksTab).toBeDefined();
+});

--- a/src/features/mechant/leads/ui/EnabledToggleCard.test.tsx
+++ b/src/features/mechant/leads/ui/EnabledToggleCard.test.tsx
@@ -1,0 +1,5 @@
+import EnabledToggleCard from "./EnabledToggleCard";
+
+test("EnabledToggleCard should be defined", () => {
+  expect(EnabledToggleCard).toBeDefined();
+});

--- a/src/features/mechant/leads/ui/FieldsEditor.test.tsx
+++ b/src/features/mechant/leads/ui/FieldsEditor.test.tsx
@@ -1,0 +1,5 @@
+import FieldsEditor from "./FieldsEditor";
+
+test("FieldsEditor should be defined", () => {
+  expect(FieldsEditor).toBeDefined();
+});

--- a/src/features/mechant/leads/ui/LeadsTable.test.tsx
+++ b/src/features/mechant/leads/ui/LeadsTable.test.tsx
@@ -1,0 +1,5 @@
+import LeadsTable from "./LeadsTable";
+
+test("LeadsTable should be defined", () => {
+  expect(LeadsTable).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/AddressForm.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/AddressForm.test.tsx
@@ -1,0 +1,5 @@
+import AddressForm from "./AddressForm";
+
+test("AddressForm should be defined", () => {
+  expect(AddressForm).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/GeneralInfoForm.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/GeneralInfoForm.test.tsx
@@ -1,0 +1,5 @@
+import GeneralInfoForm from "./GeneralInfoForm";
+
+test("GeneralInfoForm should be defined", () => {
+  expect(GeneralInfoForm).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/LogoUploader.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/LogoUploader.test.tsx
@@ -1,0 +1,5 @@
+import LogoUploader from "./LogoUploader";
+
+test("LogoUploader should be defined", () => {
+  expect(LogoUploader).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/PoliciesForm.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/PoliciesForm.test.tsx
@@ -1,0 +1,5 @@
+import PoliciesForm from "./PoliciesForm";
+
+test("PoliciesForm should be defined", () => {
+  expect(PoliciesForm).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/SocialLinksEditor.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/SocialLinksEditor.test.tsx
@@ -1,0 +1,5 @@
+import SocialLinksEditor from "./SocialLinksEditor";
+
+test("SocialLinksEditor should be defined", () => {
+  expect(SocialLinksEditor).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/SocialLinksSection.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/SocialLinksSection.test.tsx
@@ -1,0 +1,5 @@
+import SocialLinksSection from "./SocialLinksSection";
+
+test("SocialLinksSection should be defined", () => {
+  expect(SocialLinksSection).toBeDefined();
+});

--- a/src/features/mechant/merchant-settings/ui/WorkingHoursForm.test.tsx
+++ b/src/features/mechant/merchant-settings/ui/WorkingHoursForm.test.tsx
@@ -1,0 +1,5 @@
+import WorkingHoursForm from "./WorkingHoursForm";
+
+test("WorkingHoursForm should be defined", () => {
+  expect(WorkingHoursForm).toBeDefined();
+});

--- a/src/features/mechant/products/ui/AttributesEditor.test.tsx
+++ b/src/features/mechant/products/ui/AttributesEditor.test.tsx
@@ -1,0 +1,5 @@
+import AttributesEditor from "./AttributesEditor";
+
+test("AttributesEditor should be defined", () => {
+  expect(AttributesEditor).toBeDefined();
+});

--- a/src/features/mechant/products/ui/EditProductDialog.test.tsx
+++ b/src/features/mechant/products/ui/EditProductDialog.test.tsx
@@ -1,0 +1,5 @@
+import EditProductDialog from "./EditProductDialog";
+
+test("EditProductDialog should be defined", () => {
+  expect(EditProductDialog).toBeDefined();
+});

--- a/src/features/mechant/products/ui/OfferEditor.test.tsx
+++ b/src/features/mechant/products/ui/OfferEditor.test.tsx
@@ -1,0 +1,5 @@
+import OfferEditor from "./OfferEditor";
+
+test("OfferEditor should be defined", () => {
+  expect(OfferEditor).toBeDefined();
+});

--- a/src/features/mechant/products/ui/ProductsActions.test.tsx
+++ b/src/features/mechant/products/ui/ProductsActions.test.tsx
@@ -1,0 +1,5 @@
+import ProductsActions from "./ProductsActions";
+
+test("ProductsActions should be defined", () => {
+  expect(ProductsActions).toBeDefined();
+});

--- a/src/features/mechant/prompt-studio/ui/AdvancedTemplatePane.test.tsx
+++ b/src/features/mechant/prompt-studio/ui/AdvancedTemplatePane.test.tsx
@@ -1,0 +1,5 @@
+import { AdvancedTemplatePane } from "./AdvancedTemplatePane";
+
+test("AdvancedTemplatePane should be defined", () => {
+  expect(AdvancedTemplatePane).toBeDefined();
+});

--- a/src/features/mechant/prompt-studio/ui/ChatSimulator.test.tsx
+++ b/src/features/mechant/prompt-studio/ui/ChatSimulator.test.tsx
@@ -1,0 +1,5 @@
+import { ChatSimulator } from "./ChatSimulator";
+
+test("ChatSimulator should be defined", () => {
+  expect(ChatSimulator).toBeDefined();
+});

--- a/src/features/mechant/prompt-studio/ui/LivePreviewPane.test.tsx
+++ b/src/features/mechant/prompt-studio/ui/LivePreviewPane.test.tsx
@@ -1,0 +1,5 @@
+import { LivePreviewPane } from "./LivePreviewPane";
+
+test("LivePreviewPane should be defined", () => {
+  expect(LivePreviewPane).toBeDefined();
+});

--- a/src/features/mechant/prompt-studio/ui/PromptToolbar.test.tsx
+++ b/src/features/mechant/prompt-studio/ui/PromptToolbar.test.tsx
@@ -1,0 +1,5 @@
+import { PromptToolbar } from "./PromptToolbar";
+
+test("PromptToolbar should be defined", () => {
+  expect(PromptToolbar).toBeDefined();
+});

--- a/src/features/mechant/prompt-studio/ui/QuickSetupPane.test.tsx
+++ b/src/features/mechant/prompt-studio/ui/QuickSetupPane.test.tsx
@@ -1,0 +1,5 @@
+import { QuickSetupPane } from "./QuickSetupPane";
+
+test("QuickSetupPane should be defined", () => {
+  expect(QuickSetupPane).toBeDefined();
+});

--- a/src/features/mechant/storefront-theme/ui/ButtonStyleSelect.test.tsx
+++ b/src/features/mechant/storefront-theme/ui/ButtonStyleSelect.test.tsx
@@ -1,0 +1,5 @@
+import { ButtonStyleSelect } from "./ButtonStyleSelect";
+
+test("ButtonStyleSelect should be defined", () => {
+  expect(ButtonStyleSelect).toBeDefined();
+});

--- a/src/features/mechant/storefront-theme/ui/ColorPickerField.test.tsx
+++ b/src/features/mechant/storefront-theme/ui/ColorPickerField.test.tsx
@@ -1,0 +1,5 @@
+import { ColorPickerField } from "./ColorPickerField";
+
+test("ColorPickerField should be defined", () => {
+  expect(ColorPickerField).toBeDefined();
+});

--- a/src/features/mechant/storefront-theme/ui/SlugLinkField.test.tsx
+++ b/src/features/mechant/storefront-theme/ui/SlugLinkField.test.tsx
@@ -1,0 +1,5 @@
+import { SlugLinkField } from "./SlugLinkField";
+
+test("SlugLinkField should be defined", () => {
+  expect(SlugLinkField).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add basic definition tests for merchant category dialogs and utilities
- cover merchant channels, knowledge, leads, settings, and product dialogs
- include placeholder tests for prompt-studio and storefront theme components

## Testing
- `npm test` *(fails: Failed to resolve import "@/assets/Shopify.svg" in IntegrationsSection.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a90563cbdc8322afc1a5c8e1b06825