### PR TITLE
fix failing merchant page tests

### DIFF
--- a/src/features/landing/ui/Navbar.test.tsx
+++ b/src/features/landing/ui/Navbar.test.tsx
@@ -3,7 +3,10 @@ import userEvent from "@testing-library/user-event";
 import Navbar from "./Navbar";
 import { renderWithProviders } from "@/test/test-utils";
 
-vi.mock("@/context/AuthContext", () => ({ useAuth: () => ({ user: null, token: null }) }));
+vi.mock("@/context/AuthContext", () => ({
+  AuthProvider: ({ children }: any) => <>{children}</>,
+  useAuth: () => ({ user: null, token: null }),
+}));
 
 test("renders nav links and toggles drawer", async () => {
   renderWithProviders(<Navbar />);

--- a/src/features/mechant/channels/ui/ChannelCard.test.tsx
+++ b/src/features/mechant/channels/ui/ChannelCard.test.tsx
@@ -15,6 +15,6 @@ test("يستدعي onToggle عند تغيير الحالة", async () => {
       onGuide={() => {}}
     />
   );
-  await userEvent.click(screen.getByRole("checkbox"));
+  await userEvent.click(screen.getByRole("switch"));
   expect(onToggle).toHaveBeenCalled();
 });

--- a/src/features/mechant/dashboard/ui/DashboardHeader.test.tsx
+++ b/src/features/mechant/dashboard/ui/DashboardHeader.test.tsx
@@ -21,6 +21,6 @@ test("handles tab change", async () => {
 
 test("calls refresh", async () => {
   const { refresh } = setup();
-  await userEvent.click(screen.getByRole("button", { name: /refresh/i }));
+  await userEvent.click(screen.getByRole("button", { name: /تحديث البيانات/i }));
   expect(refresh).toHaveBeenCalled();
 });

--- a/src/pages/merchant/BannersManagementPage.test.tsx
+++ b/src/pages/merchant/BannersManagementPage.test.tsx
@@ -10,12 +10,12 @@ vi.mock("@/context/AuthContext", async () => {
 
 vi.mock("@/features/store/ui/BannersEditor", () => ({ default: () => <div /> }));
 vi.mock("@/features/mechant/storefront-theme/api", () => ({
-  getStorefrontInfo: () => Promise.resolve(null),
+  getStorefrontInfo: () => Promise.resolve({ banners: [] }),
   updateStorefrontInfo: vi.fn(),
 }));
 
 
-test("renders heading", () => {
+test("renders heading", async () => {
   renderWithProviders(<BannersManagementPage />);
-  expect(screen.getByText("إدارة البانرات الإعلانية")).toBeInTheDocument();
+  expect(await screen.findByText("إدارة البانرات الإعلانية")).toBeInTheDocument();
 });

--- a/src/pages/merchant/ChatSettingsPage.test.tsx
+++ b/src/pages/merchant/ChatSettingsPage.test.tsx
@@ -9,13 +9,17 @@ vi.mock("@/context/AuthContext", async () => {
 });
 
 vi.mock("@/features/mechant/widget-config/model", () => ({
-  useWidgetSettings: () => ({ data: null, isLoading: false }),
+  useWidgetSettings: () => ({ data: null, loading: true, error: null }),
 }));
 vi.mock("@/features/mechant/widget-config/api", () => ({
   updateWidgetSettings: vi.fn(),
   syncWidgetSettings: vi.fn(),
 }));
-vi.mock("@/features/mechant/widget-config/utils", () => ({ genWidgetSnippet: () => "" }));
+vi.mock("@/features/mechant/widget-config/utils", () => ({
+  genWidgetSnippet: () => "",
+  buildEmbedScript: () => "",
+  buildChatLink: () => "",
+}));
 vi.mock("@/features/mechant/widget-config/ui/SectionCard", () => ({ default: ({ children }: any) => <div>{children}</div> }));
 vi.mock("@/features/mechant/widget-config/ui/ColorPickerButton", () => ({ default: () => <div /> }));
 vi.mock("@/features/mechant/widget-config/ui/PreviewPane", () => ({ default: () => <div /> }));

--- a/src/pages/merchant/KnowledgePage.test.tsx
+++ b/src/pages/merchant/KnowledgePage.test.tsx
@@ -1,11 +1,16 @@
 import { screen } from "@testing-library/react";
 import KnowledgePage from "./KnowledgePage";
 import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
 
-vi.mock("@/features/mechant/dashboard/ui/MessagesTimelineChart", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/dashboard/ui/ProductsChart", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/dashboard/ui/KeywordsChart", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/dashboard/ui/ChannelsPieChart", () => ({ default: () => <div /> }));
+vi.mock("@/context/AuthContext", async () => {
+  const actual: any = await vi.importActual("@/context/AuthContext");
+  return { ...actual, useAuth: () => ({ user: { merchantId: "m1" } }) };
+});
+
+vi.mock("@/features/mechant/knowledge/ui/DocsTab", () => ({ default: () => <div /> }));
+vi.mock("@/features/mechant/knowledge/ui/LinksTab", () => ({ default: () => <div /> }));
+vi.mock("@/features/mechant/knowledge/ui/FaqsTab", () => ({ default: () => <div /> }));
 
 test("renders heading", () => {
   renderWithProviders(<KnowledgePage />);

--- a/src/pages/merchant/LeadsManagerPage.test.tsx
+++ b/src/pages/merchant/LeadsManagerPage.test.tsx
@@ -3,12 +3,30 @@ import LeadsManagerPage from "./LeadsManagerPage";
 import { renderWithProviders } from "@/test/test-utils";
 import { vi } from "vitest";
 
+vi.mock("@/context/AuthContext", async () => {
+  const actual: any = await vi.importActual("@/context/AuthContext");
+  return { ...actual, useAuth: () => ({ user: { merchantId: "m1" } }) };
+});
+
 vi.mock("@/features/mechant/leads/ui/EnabledToggleCard", () => ({ default: () => <div /> }));
 vi.mock("@/features/mechant/leads/ui/FieldsEditor", () => ({ default: () => <div /> }));
 vi.mock("@/features/mechant/leads/ui/LeadsTable", () => ({ default: () => <div /> }));
 
 vi.mock("@/features/mechant/leads/hooks", () => ({
-  useLeadsSettings: () => ({ loading: false, error: null, enabled: true, fields: [], leads: [], saveAll: vi.fn(), refreshAll: vi.fn(), addField: vi.fn(), removeField: vi.fn(), updateField: vi.fn(), saving: false }),
+  useLeadsManager: () => ({
+    loading: false,
+    error: null,
+    enabled: true,
+    fields: [],
+    leads: [],
+    saving: false,
+    saveAll: vi.fn(),
+    refreshAll: vi.fn(),
+    addField: vi.fn(),
+    removeField: vi.fn(),
+    updateField: vi.fn(),
+    setEnabled: vi.fn(),
+  }),
 }));
 
 test("renders heading", () => {

--- a/src/pages/merchant/PromptStudio.test.tsx
+++ b/src/pages/merchant/PromptStudio.test.tsx
@@ -31,10 +31,18 @@ vi.mock("@/features/mechant/prompt-studio/ui/PromptToolbar", () => ({
     </div>
   ),
 }));
-vi.mock("@/features/mechant/prompt-studio/ui/LivePreviewPane", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/prompt-studio/ui/AdvancedTemplatePane", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/prompt-studio/ui/ChatSimulator", () => ({ default: () => <div /> }));
-vi.mock("@/features/mechant/prompt-studio/ui/QuickSetupPane", () => ({ default: () => <div /> }));
+vi.mock("@/features/mechant/prompt-studio/ui/LivePreviewPane", () => ({
+  LivePreviewPane: () => <div />,
+}));
+vi.mock("@/features/mechant/prompt-studio/ui/AdvancedTemplatePane", () => ({
+  AdvancedTemplatePane: () => <div />,
+}));
+vi.mock("@/features/mechant/prompt-studio/ui/ChatSimulator", () => ({
+  ChatSimulator: () => <div />,
+}));
+vi.mock("@/features/mechant/prompt-studio/ui/QuickSetupPane", () => ({
+  QuickSetupPane: () => <div />,
+}));
 
 vi.mock("@/shared/ui/TagsInput", () => ({ default: () => <div /> }));
 


### PR DESCRIPTION
## Summary
- fix PromptStudio toolbar test by correcting component mocks
- stabilize merchant settings and management page tests
- adjust various UI tests to use proper labels and exports

## Testing
- `npx vitest run src/pages/merchant/PromptStudio.test.tsx`
- `npx vitest run src/pages/merchant/ChatSettingsPage.test.tsx`
- `npx vitest run src/pages/merchant/LeadsManagerPage.test.tsx`
- `npx vitest run src/pages/merchant/BannersManagementPage.test.tsx`
- `npx vitest run src/pages/merchant/KnowledgePage.test.tsx`
- `npx vitest run src/features/mechant/channels/ui/ChannelCard.test.tsx`
- `npx vitest run src/features/landing/ui/Navbar.test.tsx`
- `npx vitest run src/features/mechant/dashboard/ui/DashboardHeader.test.tsx`
- `npm test -- --run` *(fails: terminated early due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68a90b5b8fa08322b5ca6f52b50c579f