### PR TITLE
Add tests for landing, store, and widget components

### DIFF
--- a/src/features/landing/seo/JsonLd.test.tsx
+++ b/src/features/landing/seo/JsonLd.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import JsonLd from "./JsonLd";
+
+test("renders JSON-LD script", () => {
+  render(<JsonLd />);
+  const script = document.querySelector(
+    'script[type="application/ld+json"]'
+  ) as HTMLScriptElement | null;
+  expect(script).not.toBeNull();
+  const data = JSON.parse(script?.textContent || "null");
+  expect(data["@type"]).toBe("SoftwareApplication");
+});

--- a/src/features/landing/seo/SEOHead.test.tsx
+++ b/src/features/landing/seo/SEOHead.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import SEOHead from "./SEOHead";
+
+test("sets html attrs and meta", () => {
+  document.documentElement.lang = "";
+  document.documentElement.dir = "";
+  render(<SEOHead />);
+  expect(document.documentElement.lang).toBe("ar");
+  expect(document.documentElement.dir).toBe("rtl");
+  expect(document.title).toBe("كليم — مساعد متاجر ذكي بالعربية");
+  const meta = document.head.querySelector('meta[name="description"]');
+  expect(meta?.getAttribute("content")).toContain("بوت عربي");
+});

--- a/src/features/landing/ui/CookieConsent.test.tsx
+++ b/src/features/landing/ui/CookieConsent.test.tsx
@@ -1,0 +1,11 @@
+import { screen, fireEvent } from "@testing-library/react";
+import CookieConsent from "./CookieConsent";
+import { renderWithProviders } from "@/test/test-utils";
+
+test("accepts cookies and saves flag", () => {
+  localStorage.removeItem("cookie-ok");
+  renderWithProviders(<CookieConsent />);
+  expect(screen.getByText(/نستخدم ملفات تعريف الارتباط/)).toBeInTheDocument();
+  fireEvent.click(screen.getByText("موافقة"));
+  expect(localStorage.getItem("cookie-ok")).toBe("1");
+});

--- a/src/features/mechant/widget-config/ui/ColorPickerButton.test.tsx
+++ b/src/features/mechant/widget-config/ui/ColorPickerButton.test.tsx
@@ -1,0 +1,14 @@
+import { render } from "@testing-library/react";
+import ColorPickerButton from "./ColorPickerButton";
+import { fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+
+test("calls onChange when color changes", () => {
+  const handle = vi.fn();
+  const { container } = render(
+    <ColorPickerButton colorHex="#ff0000" onChange={handle} />
+  );
+  const input = container.querySelector('input[type="color"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { value: "#00ff00" } });
+  expect(handle).toHaveBeenCalledWith("#00ff00");
+});

--- a/src/features/mechant/widget-config/ui/PreviewPane.test.tsx
+++ b/src/features/mechant/widget-config/ui/PreviewPane.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import PreviewPane from "./PreviewPane";
+
+test("writes embed tag into iframe", async () => {
+  render(<PreviewPane embedTag="<div id='test'>Hi</div>" />);
+  const iframe = screen.getByTitle("Chat Preview") as HTMLIFrameElement;
+  await waitFor(() =>
+    expect(iframe.contentDocument?.body.innerHTML).toContain("test")
+  );
+});

--- a/src/features/mechant/widget-config/ui/SectionCard.test.tsx
+++ b/src/features/mechant/widget-config/ui/SectionCard.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from "@testing-library/react";
+import SectionCard from "./SectionCard";
+
+test("renders children", () => {
+  render(<SectionCard>content</SectionCard>);
+  expect(screen.getByText("content")).toBeInTheDocument();
+});

--- a/src/features/mechant/widget-config/ui/WidgetChatUI.test.tsx
+++ b/src/features/mechant/widget-config/ui/WidgetChatUI.test.tsx
@@ -1,0 +1,27 @@
+import { screen, waitFor } from "@testing-library/react";
+import WidgetChatUI from "./WidgetChatUI";
+import { vi } from "vitest";
+import { renderWithProviders } from "@/test/test-utils";
+
+vi.mock("@/features/mechant/Conversations/api/messages", () => ({
+  fetchSessionMessages: vi.fn().mockResolvedValue([]),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../hooks", () => ({ useChatWebSocket: vi.fn() }));
+
+const settings = {
+  merchantId: "m1",
+  botName: "Bot",
+  welcomeMessage: "مرحبا",
+  brandColor: "#000",
+  fontFamily: "Arial",
+  headerBgColor: "#000",
+  bodyBgColor: "#fff",
+};
+
+Element.prototype.scrollIntoView = vi.fn();
+
+test("shows welcome message", async () => {
+  renderWithProviders(<WidgetChatUI settings={settings} />);
+  await waitFor(() => expect(screen.getByText("مرحبا")).toBeInTheDocument());
+});

--- a/src/features/store/ui/BannersEditor.test.tsx
+++ b/src/features/store/ui/BannersEditor.test.tsx
@@ -1,0 +1,9 @@
+import { screen } from "@testing-library/react";
+import BannersEditor from "./BannersEditor";
+import { renderWithProviders } from "@/test/test-utils";
+
+test("renders banner editor basics", () => {
+  renderWithProviders(<BannersEditor merchantId="m1" banners={[]} onChange={() => {}} />);
+  expect(screen.getByText(/البنرات: 0\/5/)).toBeInTheDocument();
+  expect(screen.getByText("حفظ التغييرات")).toBeInTheDocument();
+});

--- a/src/features/store/ui/CategoryFilter.test.tsx
+++ b/src/features/store/ui/CategoryFilter.test.tsx
@@ -1,0 +1,18 @@
+import { screen, fireEvent } from "@testing-library/react";
+import { CategoryFilter } from "./CategoryFilter";
+import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
+
+test("renders categories and handles selection", () => {
+  const categories = [
+    { _id: "1", name: "Cat1" },
+    { _id: "2", name: "Cat2" },
+  ];
+  const handle = vi.fn();
+  renderWithProviders(
+    <CategoryFilter categories={categories as any} activeCategory={null} onChange={handle} />
+  );
+  expect(screen.getByText("جميع التصنيفات")).toBeInTheDocument();
+  fireEvent.click(screen.getByText("Cat1"));
+  expect(handle).toHaveBeenCalledWith("1");
+});

--- a/src/features/store/ui/CustomerInfoForm.test.tsx
+++ b/src/features/store/ui/CustomerInfoForm.test.tsx
@@ -1,0 +1,24 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import CustomerInfoForm from "./CustomerInfoForm";
+import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
+
+vi.mock("@/shared/api/axios", () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+test("submits customer info", async () => {
+  vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("uuid");
+  const onComplete = vi.fn();
+  renderWithProviders(<CustomerInfoForm merchantId="m1" onComplete={onComplete} />);
+  fireEvent.change(screen.getByLabelText(/الاسم/), { target: { value: "Ali" } });
+  fireEvent.change(screen.getByLabelText(/رقم الجوال/), { target: { value: "123" } });
+  fireEvent.change(screen.getByLabelText(/العنوان/), { target: { value: "Street" } });
+  fireEvent.click(screen.getByRole("button", { name: "متابعة" }));
+  await waitFor(() =>
+    expect(onComplete).toHaveBeenCalledWith({ name: "Ali", phone: "123", address: "Street" })
+  );
+});

--- a/src/features/store/ui/Footer.test.tsx
+++ b/src/features/store/ui/Footer.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from "@testing-library/react";
+import { Footer } from "./Footer";
+import { renderWithProviders } from "@/test/test-utils";
+
+test("renders footer info", () => {
+  const merchant: any = {
+    name: "متجري",
+    logoUrl: "",
+    businessDescription: "",
+    socialLinks: {},
+    phone: "123",
+    addresses: [],
+    workingHours: [],
+  };
+  const categories: any = [{ _id: "1", name: "Cat" }];
+  renderWithProviders(<Footer merchant={merchant} categories={categories} />);
+  expect(screen.getByText("متجري")).toBeInTheDocument();
+  expect(screen.getByText("Cat")).toBeInTheDocument();
+});

--- a/src/features/store/ui/LiteIdentityCard.test.tsx
+++ b/src/features/store/ui/LiteIdentityCard.test.tsx
@@ -1,0 +1,24 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import LiteIdentityCard from "./LiteIdentityCard";
+import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
+
+vi.mock("@/shared/api/axios", () => ({
+  default: { post: vi.fn().mockResolvedValue({}) },
+}));
+vi.mock("@/shared/utils/session", () => ({ getSessionId: vi.fn().mockReturnValue("sid") }));
+vi.mock("@/shared/utils/customer", () => ({
+  getLocalCustomer: () => ({ name: "", phone: "", address: "" }),
+  saveLocalCustomer: vi.fn(),
+}));
+
+import { saveLocalCustomer } from "@/shared/utils/customer";
+import axios from "@/shared/api/axios";
+
+test("saves customer info", async () => {
+  renderWithProviders(<LiteIdentityCard merchantId="m1" />);
+  fireEvent.change(screen.getByLabelText(/الجوال/), { target: { value: "111" } });
+  fireEvent.click(screen.getByText("حفظ"));
+  await waitFor(() => expect(axios.post).toHaveBeenCalled());
+  expect(saveLocalCustomer).toHaveBeenCalled();
+});

--- a/src/features/store/ui/ProductGrid.test.tsx
+++ b/src/features/store/ui/ProductGrid.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import { ProductGrid } from "./ProductGrid";
+import { vi } from "vitest";
+
+vi.mock("./ProductCard", () => ({
+  ProductCard: ({ product }: any) => <div data-testid="product">{product.name}</div>,
+}));
+
+test("shows empty state when no products", () => {
+  renderWithProviders(
+    <ProductGrid products={[]} onAddToCart={() => {}} onOpen={() => {}} />
+  );
+  expect(screen.getByText("لم يتم العثور على منتجات")).toBeInTheDocument();
+});
+
+test("renders products when provided", () => {
+  const products: any = [{ _id: "1", name: "P1", price: 1 }];
+  renderWithProviders(
+    <ProductGrid products={products} onAddToCart={() => {}} onOpen={() => {}} />
+  );
+  expect(screen.getByTestId("product")).toBeInTheDocument();
+});

--- a/src/features/store/ui/StoreHeader.test.tsx
+++ b/src/features/store/ui/StoreHeader.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import { StoreHeader } from "./StoreHeader";
+
+test("renders store name", () => {
+  const merchant: any = { name: "متجر", logoUrl: "", businessDescription: "", phone: null, addresses: [], workingHours: [] };
+  const storefront: any = { primaryColor: "#000", secondaryColor: "#fff", buttonStyle: "rounded" };
+  renderWithProviders(<StoreHeader merchant={merchant} storefront={storefront} />);
+  expect(screen.getByText("متجر")).toBeInTheDocument();
+});

--- a/src/features/store/ui/StoreNavbar.test.tsx
+++ b/src/features/store/ui/StoreNavbar.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import { StoreNavbar } from "./StoreNavbar";
+import { vi } from "vitest";
+
+window.matchMedia = window.matchMedia || function () {
+  return {
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  } as any;
+};
+
+vi.mock("@/context/CartContext", () => ({ useCart: () => ({ items: [] }) }));
+vi.mock("@/shared/utils/session", () => ({ getSessionId: () => "sid" }));
+vi.mock("@/shared/utils/customer", () => ({ getLocalCustomer: () => ({}) }));
+vi.mock("./CartDialog", () => ({ default: () => <div data-testid="cart" /> }));
+vi.mock("react-router-dom", async (orig) => {
+  const actual = await orig();
+  return { ...actual, useParams: () => ({ slugOrId: "s1" }), useNavigate: () => vi.fn() };
+});
+
+test("renders navbar with merchant name", () => {
+  const merchant: any = { _id: "m1", name: "متجري", logoUrl: "" };
+  const storefront: any = { primaryColor: "#000" };
+  renderWithProviders(<StoreNavbar merchant={merchant} storefront={storefront} />);
+  expect(screen.getByText("متجري")).toBeInTheDocument();
+});

--- a/src/pages/onboarding/SyncPage.test.tsx
+++ b/src/pages/onboarding/SyncPage.test.tsx
@@ -1,0 +1,36 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import SyncPage from "./SyncPage";
+import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({ user: { merchantId: "m1" }, token: "t" }),
+  AuthProvider: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("react-router-dom", async (orig) => {
+  const actual = await orig();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+vi.mock("@/features/integtarions/api/integrationsApi", () => ({
+  getIntegrationsStatus: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("@/features/integtarions/api/catalogApi", () => ({
+  syncCatalog: vi.fn().mockResolvedValue({ imported: 1, updated: 2 }),
+}));
+vi.mock("@/auth/AuthLayout", () => ({ default: ({ children }: any) => <div>{children}</div> }));
+
+import { syncCatalog } from "@/features/integtarions/api/catalogApi";
+
+test("initial status", () => {
+  renderWithProviders(<SyncPage />);
+  expect(screen.getByText("جاهز للمزامنة")).toBeInTheDocument();
+});
+
+test("sync button triggers catalog sync", async () => {
+  renderWithProviders(<SyncPage />);
+  fireEvent.click(screen.getByText("مزامنة الآن"));
+  await waitFor(() => expect(syncCatalog).toHaveBeenCalled());
+  await waitFor(() =>
+    expect(screen.getByText("اكتملت المزامنة!")).toBeInTheDocument()
+  );
+});

--- a/src/pages/store/AboutPage.test.tsx
+++ b/src/pages/store/AboutPage.test.tsx
@@ -1,0 +1,19 @@
+import { screen, waitFor } from "@testing-library/react";
+import AboutPage from "./AboutPage";
+import { renderWithProviders } from "@/test/test-utils";
+import { vi } from "vitest";
+
+vi.mock("@/shared/api/axios", () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: { merchant: { name: "متجر" } } }),
+  },
+}));
+vi.mock("react-router-dom", async (orig) => {
+  const actual = await orig();
+  return { ...actual, useParams: () => ({ slugOrId: "s1" }), useNavigate: () => vi.fn() };
+});
+
+test("loads merchant info", async () => {
+  renderWithProviders(<AboutPage />);
+  await waitFor(() => expect(screen.getByText("متجر")).toBeInTheDocument());
+});

--- a/src/test/test-utils.test.tsx
+++ b/src/test/test-utils.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, waitFor } from "./test-utils";
+import { vi } from "vitest";
+
+test("renderWithProviders renders children", () => {
+  renderWithProviders(<div>hello</div>);
+  expect(screen.getByText("hello")).toBeInTheDocument();
+});
+
+test("waitFor resolves after delay", async () => {
+  vi.useFakeTimers();
+  const promise = waitFor(50);
+  vi.advanceTimersByTime(50);
+  await expect(promise).resolves.toBeUndefined();
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- cover landing SEO helpers and cookie consent behavior
- add tests for store UI widgets and merchant pages
- verify widget config and onboarding sync flows

## Testing
- `npx vitest run src/features/landing/seo/JsonLd.test.tsx src/features/landing/seo/SEOHead.test.tsx src/features/landing/ui/CookieConsent.test.tsx src/features/store/ui/BannersEditor.test.tsx src/features/store/ui/CategoryFilter.test.tsx src/features/store/ui/CustomerInfoForm.test.tsx src/features/store/ui/Footer.test.tsx src/features/store/ui/LiteIdentityCard.test.tsx src/features/store/ui/ProductGrid.test.tsx src/features/store/ui/StoreHeader.test.tsx src/features/store/ui/StoreNavbar.test.tsx src/features/mechant/widget-config/ui/ColorPickerButton.test.tsx src/features/mechant/widget-config/ui/PreviewPane.test.tsx src/features/mechant/widget-config/ui/SectionCard.test.tsx src/features/mechant/widget-config/ui/WidgetChatUI.test.tsx src/pages/store/AboutPage.test.tsx src/pages/onboarding/SyncPage.test.tsx src/test/test-utils.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a90c69d36883228f5260f8f1723748